### PR TITLE
Replace with reindex

### DIFF
--- a/pydqc/infer_schema.py
+++ b/pydqc/infer_schema.py
@@ -110,6 +110,8 @@ def _cal_column_stat(sample_data, col, col_type):
     # only sample_nan_per and sample_num_uni
     else:
         if len(sample_data) > 0:
+            # converting to string to avoid mixed type errors
+            sample_data = sample_data.astype(str)
             col_stat['sample_num_uni'] = len(np.unique(sample_data))
             col_stat['sample_uni_percentage'] = round(len(np.unique(sample_data)) * 1.0 / len(sample_data), 5)
         else:

--- a/pydqc/infer_schema.py
+++ b/pydqc/infer_schema.py
@@ -203,8 +203,9 @@ def infer_schema(data, fname, output_root='', sample_size=1.0, type_threshold=0.
 
     # add include column
     full_infos_df['include'] = 1
-    full_infos_df = full_infos_df[['column', 'type', 'include', 'sample_value', 'sample_num_uni',
-                                   'sample_uni_percentage', 'sample_min', 'sample_median', 'sample_max', 'sample_std']]
+    full_infos_df = full_infos_df.reindex(
+        columns=['column', 'type', 'include', 'sample_value', 'sample_num_uni',
+                 'sample_uni_percentage', 'sample_min', 'sample_median', 'sample_max', 'sample_std'])
 
     # if base_schema is provided, we can compare with base schema
     if base_schema is not None:
@@ -218,9 +219,10 @@ def infer_schema(data, fname, output_root='', sample_size=1.0, type_threshold=0.
 
         # reorder the column
         full_infos_df['include'] = base_schema['base_include']
-        full_infos_df = full_infos_df[['column', 'base_column', 'type', 'base_type', 'include', 'sample_value',
-                                       'sample_num_uni', 'sample_uni_percentage', 'sample_min', 'sample_median',
-                                       'sample_max', 'sample_std']]
+        full_infos_df = full_infos_df.reindex(
+            columns=['column', 'base_column', 'type', 'base_type', 'include', 'sample_value',
+                     'sample_num_uni', 'sample_uni_percentage', 'sample_min', 'sample_median',
+                     'sample_max', 'sample_std'])
 
     # add data validation for type column
     val_type = DataValidation(type="list", formula1='"key,numeric,str,date"', allow_blank=False)


### PR DESCRIPTION
This bug was not reported as far as I know, but when you infer_schema on a dataframe with no numerical columns, it would raise a Key error because infer_schema was trying to reorder columns that were never created in the first place. Using reindex instead creates the empty columns if necessary.