### PR TITLE
specify scikit version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ openpyxl >= 2.5.0
 xlsxwriter >= 1.0.2
 seaborn >= 0.8.0
 matplotlib_venn >= 0.11.5
-scikit-learn
+scikit-learn>=0.20,<0.21


### PR DESCRIPTION
When running:

`from pydqc import infer_schema, data_summary`

We get an error:

`ModuleNotFoundError: No module named 'sklearn.externals.joblib'`

because this is no longer in scikit. Fixed by specifying the version of scikit-learn in the requirements.txt.