### PR TITLE
import from top level joblib instead of sklearn.externals

### DIFF
--- a/pydqc/data_compare.py
+++ b/pydqc/data_compare.py
@@ -7,7 +7,7 @@ import openpyxl
 from openpyxl.styles import Border, Side
 from openpyxl.formatting.rule import DataBar, FormatObject, Rule
 
-from sklearn.externals.joblib import Parallel, delayed
+from joblib import Parallel, delayed
 from scipy.stats import spearmanr
 
 import matplotlib.pyplot as plt

--- a/pydqc/data_consist.py
+++ b/pydqc/data_consist.py
@@ -4,7 +4,7 @@ import os
 import shutil
 
 import openpyxl
-from sklearn.externals.joblib import Parallel, delayed
+from joblib import Parallel, delayed
 
 import matplotlib.pyplot as plt
 import seaborn as sns 

--- a/pydqc/data_summary.py
+++ b/pydqc/data_summary.py
@@ -8,7 +8,7 @@ from openpyxl.styles import Border, Side
 from openpyxl.formatting.rule import DataBar, FormatObject, Rule
 
 import datetime
-from sklearn.externals.joblib import Parallel, delayed
+from joblib import Parallel, delayed
 
 import matplotlib.pyplot as plt
 

--- a/pydqc/infer_schema.py
+++ b/pydqc/infer_schema.py
@@ -8,7 +8,7 @@ from openpyxl.styles import Font, PatternFill
 from openpyxl.formatting.rule import FormulaRule
 from openpyxl.worksheet.datavalidation import DataValidation
 
-from sklearn.externals.joblib import Parallel, delayed
+from joblib import Parallel, delayed
 import xlsxwriter
 
 import warnings


### PR DESCRIPTION
I was getting an error
`ModuleNotFoundError: No module named 'sklearn.externals.joblib'`, which after some googling[1] shows that sklearn removed that from the externals lib, and expects it to just be at the top level.

[1]: https://stackoverflow.com/questions/61893719/importerror-cannot-import-name-joblib-from-sklearn-externals